### PR TITLE
Refactor: better configs

### DIFF
--- a/autoload/alternaut.vim
+++ b/autoload/alternaut.vim
@@ -54,6 +54,10 @@ func! alternaut#IsTestFile(file_path) abort
   let l:full_file_path = fnamemodify(a:file_path, ':p')
   let l:lang_definition = alternaut#utils#get_language_config(&filetype, l:full_file_path)
 
+  if l:lang_definition is# v:null
+    return v:false
+  endif
+
   if alternaut#search#find_parent_test_directory(a:file_path, l:lang_definition) isnot# v:null
     return v:true
   endif

--- a/autoload/alternaut/config.vim
+++ b/autoload/alternaut/config.vim
@@ -1,5 +1,23 @@
 let s:REQUIRED_KEYS = ['file_naming_conventions', 'directory_naming_conventions', 'file_extensions']
 
+func! alternaut#config#load_interceptors(filetype) abort
+  let l:all_interceptors = get(g:, 'alternaut#interceptors', {})
+  let l:interceptors = get(l:all_interceptors, a:filetype, [])
+
+  for l:interceptor in l:interceptors
+    if type(l:interceptor) isnot# v:t_func
+      call alternaut#print#error('Error:')
+      call alternaut#print#(' alternaut interceptors must be functions.')
+
+      " TODO: Link to a help page.
+
+      return []
+    endif
+  endfor
+
+  return l:interceptors
+endfunc
+
 func! alternaut#config#load_conventions(filetype) abort
   let l:all_conventions = get(g:, 'alternaut#conventions', {})
   let l:ft_conventions = get(l:all_conventions, a:filetype, v:null)

--- a/autoload/alternaut/config.vim
+++ b/autoload/alternaut/config.vim
@@ -1,6 +1,11 @@
 let s:REQUIRED_KEYS = ['file_naming_conventions', 'directory_naming_conventions', 'file_extensions']
 
 func! alternaut#config#load_interceptors(filetype) abort
+  " Support the legacy interceptor registry.
+  if !exists('alternaut#interceptors')
+    return get(g:alternaut#private#interceptors, a:filetype, [])
+  endif
+
   let l:all_interceptors = get(g:, 'alternaut#interceptors', {})
   let l:interceptors = get(l:all_interceptors, a:filetype, [])
 

--- a/autoload/alternaut/config.vim
+++ b/autoload/alternaut/config.vim
@@ -1,0 +1,29 @@
+let s:REQUIRED_KEYS = ['file_naming_conventions', 'directory_naming_conventions', 'file_extensions']
+
+func! alternaut#config#load(filetype) abort
+  let l:all_conventions = get(g:, 'alternaut#conventions', {})
+  let l:ft_conventions = get(l:all_conventions, a:filetype, v:null)
+
+  if l:ft_conventions isnot# v:null
+    return s:validate_conventions(l:ft_conventions, a:filetype)
+  endif
+
+  return v:null
+endfunc
+
+func! s:validate_conventions(conventions, filetype) abort
+  for l:key in s:REQUIRED_KEYS
+    if !has_key(a:conventions, l:key)
+      call alternaut#print#error('Error:')
+      call alternaut#print#(' the alternaut conventions for ')
+      call alternaut#print#code(a:filetype)
+      call alternaut#print#(' are invalid.')
+
+      " TODO: Link to a help page.
+
+      return v:null
+    endif
+  endfor
+
+  return a:conventions
+endfunc

--- a/autoload/alternaut/config.vim
+++ b/autoload/alternaut/config.vim
@@ -1,6 +1,6 @@
 let s:REQUIRED_KEYS = ['file_naming_conventions', 'directory_naming_conventions', 'file_extensions']
 
-func! alternaut#config#load(filetype) abort
+func! alternaut#config#load_conventions(filetype) abort
   let l:all_conventions = get(g:, 'alternaut#conventions', {})
   let l:ft_conventions = get(l:all_conventions, a:filetype, v:null)
 

--- a/autoload/alternaut/config.vim
+++ b/autoload/alternaut/config.vim
@@ -12,9 +12,10 @@ func! alternaut#config#load_interceptors(filetype) abort
   for l:interceptor in l:interceptors
     if type(l:interceptor) isnot# v:t_func
       call alternaut#print#error('Error:')
-      call alternaut#print#(' alternaut interceptors must be functions.')
-
-      " TODO: Link to a help page.
+      call alternaut#print#(" interceptors must be functions.\n")
+      call alternaut#print#('See ')
+      call alternaut#print#code(':help alternaut#interceptors')
+      call alternaut#print#(' for details.')
 
       return []
     endif
@@ -38,11 +39,12 @@ func! s:validate_conventions(conventions, filetype) abort
   for l:key in s:REQUIRED_KEYS
     if !has_key(a:conventions, l:key)
       call alternaut#print#error('Error:')
-      call alternaut#print#(' the alternaut conventions for ')
+      call alternaut#print#(' the conventions for ')
       call alternaut#print#code(a:filetype)
-      call alternaut#print#(' are invalid.')
-
-      " TODO: Link to a help page.
+      call alternaut#print#(" are invalid.\n")
+      call alternaut#print#('See ')
+      call alternaut#print#code(':help alternaut#conventions')
+      call alternaut#print#(' for details.')
 
       return v:null
     endif

--- a/autoload/alternaut/print.vim
+++ b/autoload/alternaut/print.vim
@@ -1,0 +1,26 @@
+" Syntax-highlighted echo messages.
+func! s:print(highlight_token, messages) abort
+  execute 'echohl ' . a:highlight_token
+  echon join(a:messages, '')
+  echohl None
+endfunc
+
+func! alternaut#print#error(...) abort
+  call s:print('Error', a:000)
+endfunc
+
+func! alternaut#print#string(...) abort
+  call s:print('String', a:000)
+endfunc
+
+func! alternaut#print#function(...) abort
+  call s:print('Function', a:000)
+endfunc
+
+func! alternaut#print#code(...) abort
+  call s:print('Comment', a:000)
+endfunc
+
+func! alternaut#print#(...) abort
+  call s:print('None', a:000)
+endfunc

--- a/autoload/alternaut/search.vim
+++ b/autoload/alternaut/search.vim
@@ -47,6 +47,10 @@ func! alternaut#search#find_matching_test_file(filetype, source_file) abort
   let l:curdir = alternaut#utils#get_current_dir(a:source_file)
   let l:definition = alternaut#utils#get_language_config(a:filetype, a:source_file)
 
+  if l:definition is# v:null
+    return v:null
+  endif
+
   return s:search_upward(l:curdir, l:definition, l:file_name)
 endfunc
 

--- a/autoload/alternaut/tests/config.vader
+++ b/autoload/alternaut/tests/config.vader
@@ -1,6 +1,8 @@
 Before:
+  let alternaut#private#interceptors = {}
   let alternaut#conventions = {}
   let alternaut#interceptors = {}
+
   let conventions = {}
   let conventions['file_naming_conventions'] = []
   let conventions['directory_naming_conventions'] = []
@@ -42,3 +44,9 @@ Execute (returns an empty array if any interceptor is invalid):
   call add(alternaut#interceptors['ft'], 'invalid value')
 
   silent AssertEqual [], alternaut#config#load_interceptors('ft')
+
+Execute (returns the legacy interceptor config if the new form is omitted):
+  unlet alternaut#interceptors
+  call alternaut#AddInterceptor('ft', { path, def -> v:null })
+
+  AssertEqual 1, len(alternaut#config#load_interceptors('ft'))

--- a/autoload/alternaut/tests/config.vader
+++ b/autoload/alternaut/tests/config.vader
@@ -1,5 +1,6 @@
 Before:
   let alternaut#conventions = {}
+  let alternaut#interceptors = {}
   let conventions = {}
   let conventions['file_naming_conventions'] = []
   let conventions['directory_naming_conventions'] = []
@@ -30,3 +31,14 @@ Execute (fails to load the config if missing a field):
   let alternaut#conventions['ft'] = copy(conventions)
   unlet alternaut#conventions['ft']['file_extensions']
   silent AssertEqual v:null, alternaut#config#load_conventions('ft')
+
+Execute (returns an empty interceptor array when none are defined):
+  unlet alternaut#interceptors
+
+  AssertEqual [], alternaut#config#load_interceptors('ft')
+
+Execute (returns an empty array if any interceptor is invalid):
+  let alternaut#interceptors['ft'] = []
+  call add(alternaut#interceptors['ft'], 'invalid value')
+
+  silent AssertEqual [], alternaut#config#load_interceptors('ft')

--- a/autoload/alternaut/tests/config.vader
+++ b/autoload/alternaut/tests/config.vader
@@ -6,27 +6,27 @@ Before:
   let conventions['file_extensions'] = []
 
 Execute (returns null if the file type has not been defined):
-  AssertEqual v:null, alternaut#config#load('ft')
+  AssertEqual v:null, alternaut#config#load_conventions('ft')
 
 Execute (returns the file config if defined):
   let alternaut#conventions['ft'] = conventions
 
-  AssertEqual conventions, alternaut#config#load('ft')
+  AssertEqual conventions, alternaut#config#load_conventions('ft')
 
 Execute (survives if no conventions are defined):
   unlet alternaut#conventions
 
-  AssertEqual v:null, alternaut#config#load('ft')
+  AssertEqual v:null, alternaut#config#load_conventions('ft')
 
 Execute (fails to load the config if missing a field):
   let alternaut#conventions['ft'] = copy(conventions)
   unlet alternaut#conventions['ft']['file_naming_conventions']
-  silent AssertEqual v:null, alternaut#config#load('ft')
+  silent AssertEqual v:null, alternaut#config#load_conventions('ft')
 
   let alternaut#conventions['ft'] = copy(conventions)
   unlet alternaut#conventions['ft']['directory_naming_conventions']
-  silent AssertEqual v:null, alternaut#config#load('ft')
+  silent AssertEqual v:null, alternaut#config#load_conventions('ft')
 
   let alternaut#conventions['ft'] = copy(conventions)
   unlet alternaut#conventions['ft']['file_extensions']
-  silent AssertEqual v:null, alternaut#config#load('ft')
+  silent AssertEqual v:null, alternaut#config#load_conventions('ft')

--- a/autoload/alternaut/tests/config.vader
+++ b/autoload/alternaut/tests/config.vader
@@ -1,0 +1,32 @@
+Before:
+  let alternaut#conventions = {}
+  let conventions = {}
+  let conventions['file_naming_conventions'] = []
+  let conventions['directory_naming_conventions'] = []
+  let conventions['file_extensions'] = []
+
+Execute (returns null if the file type has not been defined):
+  AssertEqual v:null, alternaut#config#load('ft')
+
+Execute (returns the file config if defined):
+  let alternaut#conventions['ft'] = conventions
+
+  AssertEqual conventions, alternaut#config#load('ft')
+
+Execute (survives if no conventions are defined):
+  unlet alternaut#conventions
+
+  AssertEqual v:null, alternaut#config#load('ft')
+
+Execute (fails to load the config if missing a field):
+  let alternaut#conventions['ft'] = copy(conventions)
+  unlet alternaut#conventions['ft']['file_naming_conventions']
+  silent AssertEqual v:null, alternaut#config#load('ft')
+
+  let alternaut#conventions['ft'] = copy(conventions)
+  unlet alternaut#conventions['ft']['directory_naming_conventions']
+  silent AssertEqual v:null, alternaut#config#load('ft')
+
+  let alternaut#conventions['ft'] = copy(conventions)
+  unlet alternaut#conventions['ft']['file_extensions']
+  silent AssertEqual v:null, alternaut#config#load('ft')

--- a/autoload/alternaut/utils.vim
+++ b/autoload/alternaut/utils.vim
@@ -16,7 +16,7 @@ endfunc
 
 func! alternaut#utils#get_language_config(filetype, file_path) abort
   if exists('g:alternaut#conventions')
-    return alternaut#config#load(a:filetype)
+    return alternaut#config#load_conventions(a:filetype)
   endif
 
   if !has_key(g:alternaut#private#languages, a:filetype)

--- a/autoload/alternaut/utils.vim
+++ b/autoload/alternaut/utils.vim
@@ -15,6 +15,10 @@ func! alternaut#utils#get_current_dir(file_or_directory) abort
 endfunc
 
 func! alternaut#utils#get_language_config(filetype, file_path) abort
+  if exists('g:alternaut#conventions')
+    return alternaut#config#load(a:filetype)
+  endif
+
   if !has_key(g:alternaut#private#languages, a:filetype)
     throw "No language definition for file type '" . a:filetype . "'."
   endif

--- a/autoload/alternaut/utils.vim
+++ b/autoload/alternaut/utils.vim
@@ -25,7 +25,7 @@ func! alternaut#utils#get_language_config(filetype, file_path) abort
 
   let l:lang_definition = g:alternaut#private#languages[a:filetype]
 
-  for l:Interceptor in get(g:alternaut#private#interceptors, a:filetype, [])
+  for l:Interceptor in alternaut#config#load_interceptors(a:filetype)
     let l:definition_override = l:Interceptor(a:file_path, deepcopy(l:lang_definition))
 
     " It might return null.

--- a/doc/alternaut.txt
+++ b/doc/alternaut.txt
@@ -138,7 +138,7 @@ CHANGELOG                                                  *alternaut-changelog*
 
 Initial release (unstable).
 
-0.2.0 - UNRELEASED~
+0.2.0 - Sept 21, 2020~
 
 Added:
 - Declarative configs using |alternaut#conventions|. See issue #1 for

--- a/doc/alternaut.txt
+++ b/doc/alternaut.txt
@@ -4,16 +4,149 @@ Author:   Jesse Gibson <JesseTheGibson@gmail.com>
 Homepage: https://github.com/PsychoLlama/alternaut.vim
 License:  MIT
 
+
+  Press `gO` to show the table of contents.
+
+
 ==============================================================================
-API                                                              |alternaut-api|
+OVERVIEW                                                    *alternaut-overview*
+
+Alternaut is a minimal plugin that powers quick navigation between test files
+and source code. It works by assuming a consistent directory structure and
+naming pattern, which is configurable by file type.
+
+Get started by defining a convention: |alternaut-conventions|
+
+==============================================================================
+CONFIG                                                        *alternaut-config*
+
+------------------------------------------------------------------------------
+CONVENTIONS                        *alternaut#conventions* *alternaut-conventions*
+
+Alternaut doesn't work out of the box. You have to configure it by telling it
+where to find test files by describing a set of conventions. Those conventions
+answer questions like "what's the name of the test directory" or "how are
+tests named?", that kind of thing.
+
+Here's an example for Jest + TypeScript: the Jest framework encourages you to
+keep tests in the `__tests__/` folder right next to your source code, so your
+directory structure might look like this...
+>
+  src/
+    health-check/
+      __tests__/
+        auth-utils.test.ts
+        uptime-monitor.test.ts
+      auth-utils.ts
+      uptime-monitor.ts
+
+And this is how you'd write the alternaut convention:
+>
+  let alternaut#conventions = {}
+  let alternaut#conventions['typescript'] = {
+  \   'directory_naming_conventions': ['__tests__'],
+  \   'file_extensions': ['ts', 'tsx'],
+  \   'file_naming_conventions': ['{name}.test.{ext}'],
+  \ }
+
+That tells alternaut how to behave when you're editing `typescript` files.
+`'directory_naming_conventions'` tells it where to look for tests, which in
+our case is the `__tests__/` folder, and `'file_extensions'` indicates, well,
+the file extension. Some languages have more than one.
+
+Those two fields narrow it down enough for alternaut to figure out the
+directory and file extension. The final thing it needs is the file name, and
+we assume tests have the same file name as the source code (i.e.
+`auth-utils.ts` and `auth-utils.test.ts` share the name `'auth-utils'`).
+`'file_naming_conventions'` fills that gap.
+
+As you might expect, `{name}` and `{ext}` are interpolated with real values.
+`{name}` is the file's name minus the extension (`'uptime-monitor'`, for
+example) and `{ext}` is one of the values in your extensions list.
+
+Bringing it all together: if you're editing the `src/uptime-monitor.ts` file
+and you ask alternaut to open the test file, it would look for these paths and
+return the first match:
+- `src/health-check/__tests__/uptime-monitor.test.ts`
+- `src/health-check/__tests__/uptime-monitor.test.tsx`
+- `src/__tests__/uptime-monitor.test.ts`
+- `src/__tests__/uptime-monitor.test.tsx`
+
+It checks every permutation of the test directory and file extension until it
+finds a match.
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+Here's another example with python. Say you keep your test files in a `tests/`
+folder and you typically name them `test_<the-file-name>.py`, but sometimes
+leave off the `test_` prefix.
+>
+  src/
+    tests/
+      test_jitter_buffer.py
+    jitter_buffer.py
+
+And here's the convention:
+>
+  let alternaut#conventions = {}
+  let alternaut#conventions['python'] = {
+  \   'file_naming_conventions': ['test_{name}.{ext}', '{name}.{ext}'],
+  \   'directory_naming_conventions': ['tests'],
+  \   'file_extensions': ['py'],
+  \ }
+
+That tells alternaut to look for `tests/test_{name}.py` and `tests/{name}.py`.
+
+Hopefully you get the idea.
+
+------------------------------------------------------------------------------
+INTERCEPTORS                     *alternaut#interceptors* *alternaut-interceptors*
+
+Interceptors allow you to override the conventions on a per-file basis. This
+is an advanced use case, and you probably don't need it. It's primarily useful
+when there's an oddball project that doesn't follow your typical testing
+patterns forcing you to override the conventions for that project alone.
+
+Interceptors are registered through the `alternaut#interceptors` variable.
+It's a mapping between file types and a list of functions. Each function
+executes in a series. Realistically you'll never need more than one (or even
+one at all).
+
+The interceptor is just a function that accepts the file path and the current
+file conventions. Whatever you return becomes the new file conventions.
+>
+  func s:override_project_defaults(file_path, conventions) abort
+    let a:conventions.directory_naming_conventions = ['look-here-instead']
+    return a:conventions
+  endfunc
+
+Here's an example of how you'd apply the interceptor to all lua files:
+>
+  let alternaut#interceptors = {}
+  let alternaut#interceptors['lua'] = [function('s:override_project_defaults')]
+
+==============================================================================
+API                                                              *alternaut-api*
 
 Alternaut can be used programmatically. The API is available under the
 alternaut# namespace, but it's unstable. Don't use it yet.
 
 ==============================================================================
-Changelog                                                  |alternaut-changelog|
+CHANGELOG                                                  *alternaut-changelog*
 
-0.1.0
-Initial release (unstable)
+0.1.0~
+
+Initial release (unstable).
+
+0.2.0 - UNRELEASED~
+
+Added:
+- Declarative configs using |alternaut#conventions|. See issue #1 for
+  a description of the problem.
+- Similarly, declarative interceptors using |alternaut#interceptors|.
+
+Deprecated:
+- `alternaut#RegisterLanguage(...)` and `alternaut#AddInterceptor(...)` are no
+  longer supported. Use the declarative configs instead.
 
 vim: ft=help tw=78:

--- a/doc/tags
+++ b/doc/tags
@@ -1,1 +1,9 @@
 alternaut	alternaut.txt	/*alternaut*
+alternaut#conventions	alternaut.txt	/*alternaut#conventions*
+alternaut#interceptors	alternaut.txt	/*alternaut#interceptors*
+alternaut-api	alternaut.txt	/*alternaut-api*
+alternaut-changelog	alternaut.txt	/*alternaut-changelog*
+alternaut-config	alternaut.txt	/*alternaut-config*
+alternaut-conventions	alternaut.txt	/*alternaut-conventions*
+alternaut-interceptors	alternaut.txt	/*alternaut-interceptors*
+alternaut-overview	alternaut.txt	/*alternaut-overview*


### PR DESCRIPTION
The way you define configs is changing. Instead of calling `alternaut#RegisterLanguage(...)`, set it via the global `alternaut#conventions` object.

```viml
let alternaut#conventions['typescript'] = {
      \   'file_naming_conventions': ['{name}.test.{ext}'],
      \   'directory_naming_conventions': ['__tests__'],
      \   'file_extensions': ['ts', 'tsx', 'js'],
      \ }
```

Similarly, register interceptors using the exact same pattern:
```viml
let alternaut#interceptors['typescript'] = [function('s:do_the_thing')]
```

This fixes #1.

TODO:
- [x] Write documentation detailing the config structure.
- [x] Link to that documentation in the validation logic.
- [ ] ~Improve reporting when a language convention isn't defined.~